### PR TITLE
Now fasta_seqkit_refsort supports n-genome combinations

### DIFF
--- a/docs/AVAILABLE.txt
+++ b/docs/AVAILABLE.txt
@@ -15,6 +15,7 @@
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/seqkit/seq">modules/gallvp/seqkit/seq</a></li>
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/samtools/faidx">modules/gallvp/samtools/faidx</a></li>
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/samblaster">modules/gallvp/samblaster</a></li>
+<li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/repeatmasker/repeatmasker">modules/gallvp/repeatmasker/repeatmasker</a></li>
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/plotsr">modules/gallvp/plotsr</a></li>
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/minimap2/align">modules/gallvp/minimap2/align</a></li>
 <li><a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/matlock/bam2juicer">modules/gallvp/matlock/bam2juicer</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,6 +177,11 @@
                 >
             </li>
             <li>
+                <a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/repeatmasker/repeatmasker"
+                    >modules/gallvp/repeatmasker/repeatmasker</a
+                >
+            </li>
+            <li>
                 <a href="https://github.com/gallvp/nxf-components/tree/main/modules/gallvp/plotsr"
                     >modules/gallvp/plotsr</a
                 >

--- a/modules/gallvp/custom/interleavefasta/main.nf
+++ b/modules/gallvp/custom/interleavefasta/main.nf
@@ -8,10 +8,9 @@ process CUSTOM_INTERLEAVEFASTA {
         'biocontainers/biopython:1.75' }"
 
     input:
-    tuple val(meta), path(fasta1)
-    path(fasta2)
-    val(fasta1_prefix)
-    val(fasta2_prefix)
+    tuple val(meta), path(fastas)
+    val(fasta_prefixes)
+
 
     output:
     tuple val(meta), path("*.fasta")    , emit: fasta
@@ -22,12 +21,12 @@ process CUSTOM_INTERLEAVEFASTA {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    if ("${prefix}.fasta" == "$fasta1" || "${prefix}.fasta" == "$fasta2") error "Input and output names are the same, use 'prefix' to disambiguate!"
+    if ("${prefix}.fasta" in fastas) error "Input and output names are the same, use 'prefix' to disambiguate!"
     template 'interleave_fasta.py'
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    if ("${prefix}.fasta" == "$fasta1" || "${prefix}.fasta" == "$fasta2") error "Input and output names are the same, use 'prefix' to disambiguate!"
+    if ("${prefix}.fasta" in fastas) error "Input and output names are the same, use 'prefix' to disambiguate!"
     """
     touch ${prefix}.fasta
 

--- a/modules/gallvp/custom/interleavefasta/meta.yml
+++ b/modules/gallvp/custom/interleavefasta/meta.yml
@@ -1,7 +1,7 @@
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "custom_interleavefasta"
-description: Interleaves two FASTA files, optionally prefixing IDs if there are collisions, and outputs a single interleaved FASTA file.
+description: Interleaves two FASTA files, optionally prefixing IDs if there are
+  collisions, and outputs a single interleaved FASTA file.
 keywords:
   - fasta
   - interleave
@@ -28,28 +28,17 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1' ]`
-    - fasta1:
-        type: file
-        description: First input FASTA file
-        pattern: "*.fasta"
-        ontologies:
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - fasta2:
-        type: file
-        description: Second input FASTA file
-        pattern: "*.fasta"
-        ontologies:
-          - edam: "http://edamontology.org/format_1929" # FASTA
-  - - fasta1_prefix:
-        type: string
-        description: Prefix to add to IDs from the first FASTA file if there are collisions
-  - - fasta2_prefix:
-        type: string
-        description: Prefix to add to IDs from the second FASTA file if there are collisions
+    - fastas:
+        type: list
+        description: A list of fasta files
+
+  - fasta_prefixes:
+      type: string
+      description: A space separated list of prefixes to add to IDs from the second FASTA file if there are collisions
 
 output:
-  - fasta:
-      - meta:
+  fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -60,12 +49,14 @@ output:
           pattern: "*.fasta"
           ontologies:
             - edam: "http://edamontology.org/format_1929" # FASTA
-  - versions:
-      - "versions.yml":
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
 
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@GallVp"
 maintainers:

--- a/modules/gallvp/custom/interleavefasta/templates/interleave_fasta.py
+++ b/modules/gallvp/custom/interleavefasta/templates/interleave_fasta.py
@@ -1,48 +1,53 @@
 #!/usr/bin/env python3
 
+import re
 from importlib.metadata import version
 from platform import python_version
 
 from Bio import SeqIO
 
-fasta1 = "$fasta1"
-fasta2 = "$fasta2"
-fasta1_prefix = "$fasta1_prefix"
-fasta2_prefix = "$fasta2_prefix"
-fasta_output_prefix = "$prefix"
-line_feed = "\\n"
-
 
 def main():
-    fasta1_records = list(SeqIO.parse(str(fasta1), "fasta"))
-    fasta2_records = list(SeqIO.parse(str(fasta2), "fasta"))
+    fasta_files_input = "$fastas"
+    prefixes_input = "$fasta_prefixes"
+    fasta_output_prefix = "$prefix"
 
-    fasta1_ids = {rec.id for rec in fasta1_records}
-    fasta2_ids = {rec.id for rec in fasta2_records}
-    n_fasta1 = len(fasta1_records)
-    n_fasta2 = len(fasta2_records)
-    max_n = max(n_fasta1, n_fasta2)
+    fasta_files = [f for f in re.split(r"[ ,;]", fasta_files_input) if f]
+    prefixes = [p for p in re.split(r"[ ,;]", prefixes_input) if p]
+    line_feed = "\\n"
 
-    should_prefix = bool(fasta1_ids & fasta2_ids)
-    fasta1_prefix_local = fasta1_prefix if should_prefix else ""
-    fasta2_prefix_local = fasta2_prefix if should_prefix else ""
+    all_records = []
+    all_ids = []
+    for fasta in fasta_files:
+        records = list(SeqIO.parse(str(fasta), "fasta"))
+        all_records.append(records)
+        all_ids.extend([rec.id for rec in records])
+
+    n_records_per_fasta = [len(records) for records in all_records]
+    max_n = max(n_records_per_fasta) if n_records_per_fasta else 0
+
+    should_prefix = len(set(all_ids)) != len(all_ids)
+
+    if should_prefix and (len(fasta_files) != len(prefixes)):
+        raise ValueError(
+            f"The number of prefixes ({len(prefixes)}) is not equal to the number of fasta files ({len(fasta_files)})!"
+        )
+
+    local_prefixes = prefixes if should_prefix else ["" for _ in range(0, len(fasta_files))]
 
     with open(f"{fasta_output_prefix}.fasta", "w") as out:
-        for i in range(max_n):
-            if i < n_fasta1:
-                rec = fasta1_records[i]
-                rec_id = f"{fasta1_prefix_local}{rec.id}"
-                out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
-            if i < n_fasta2:
-                rec = fasta2_records[i]
-                rec_id = f"{fasta2_prefix_local}{rec.id}"
-                out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
+        for record_idx in range(max_n):
+            for fasta_idx, fasta_records in enumerate(all_records):
+                if record_idx < len(fasta_records):
+                    rec = fasta_records[record_idx]
+                    rec_id = f"{local_prefixes[fasta_idx]}{rec.id}"
+                    out.write(f">{rec_id}{line_feed}{str(rec.seq)}{line_feed}")
 
     # Write versions
     with open("versions.yml", "w") as f_versions:
         f_versions.write('"${task.process}":\\n')
-        f_versions.write(f"    python: {python_version()}\\n")
-        f_versions.write(f"    biopython: {version('biopython')}\\n")
+        f_versions.write(f"    python: {python_version()}{line_feed}")
+        f_versions.write(f"    biopython: {version('biopython')}{line_feed}")
 
 
 if __name__ == "__main__":

--- a/modules/gallvp/custom/interleavefasta/tests/main.nf.test
+++ b/modules/gallvp/custom/interleavefasta/tests/main.nf.test
@@ -19,10 +19,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">b1\\nAAAA\\n>b2\\nCCCC\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = '' // fasta1_prefix
-                input[3] = '' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
                 """
             }
         }
@@ -44,10 +42,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">b1\\nAAAA\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = '' // fasta1_prefix
-                input[3] = '' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
                 """
             }
         }
@@ -68,10 +64,8 @@ nextflow_process {
                 def test2_fasta = new File("test2.fasta")
                 test2_fasta.text = ">id1\\nCCC\\n"
 
-                input[0] = [ [ id: 'test'], test1_fasta.toPath() ]
-                input[1] = [ test2_fasta.toPath() ]
-                input[2] = 'A_' // fasta1_prefix
-                input[3] = 'B_' // fasta2_prefix
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = 'A_ B_'
                 """
             }
         }
@@ -79,6 +73,49 @@ nextflow_process {
             assert process.success
             assert file(process.out.fasta[0][1]).text == ">A_id1\nAAA\n>B_id1\nCCC\n"
             assert snapshot(process.out).match()
+        }
+    }
+
+    test("interleavefasta - five files") {
+        when {
+            process {
+                """
+                def f1 = new File("f1.fasta"); f1.text = ">id\\nA\\n"
+                def f2 = new File("f2.fasta"); f2.text = ">id\\nB\\n"
+                def f3 = new File("f3.fasta"); f3.text = ">id\\nC\\n"
+                def f4 = new File("f4.fasta"); f4.text = ">id\\nD\\n"
+                def f5 = new File("f5.fasta"); f5.text = ">id\\nE\\n"
+
+                input[0] = [ [ id: 'test'], [ f1.toPath(), f2.toPath(), f3.toPath(), f4.toPath(), f5.toPath() ] ]
+                input[1] = 'P1_ P2_ P3_ P4_ P5_'
+                """
+            }
+        }
+        then {
+            assert process.success
+            assert file(process.out.fasta[0][1]).text == ">P1_id\nA\n>P2_id\nB\n>P3_id\nC\n>P4_id\nD\n>P5_id\nE\n"
+            assert snapshot(process.out).match()
+        }
+    }
+
+    test("interleavefasta - id collision triggers prefix - fails due to no prefix input") {
+        when {
+            process {
+                """
+                def test1_fasta = new File("test1.fasta")
+                test1_fasta.text = ">id1\\nAAA\\n"
+
+                def test2_fasta = new File("test2.fasta")
+                test2_fasta.text = ">id1\\nCCC\\n"
+
+                input[0] = [ [ id: 'test'], [ test1_fasta.toPath(), test2_fasta.toPath() ] ]
+                input[1] = ''
+                """
+            }
+        }
+        then {
+            assert ! process.success
+            assert process.stdout.toString().contains( 'is not equal to the number of fasta files' )
         }
     }
 

--- a/modules/gallvp/custom/interleavefasta/tests/main.nf.test.snap
+++ b/modules/gallvp/custom/interleavefasta/tests/main.nf.test.snap
@@ -97,5 +97,38 @@
             "nextflow": "25.04.4"
         },
         "timestamp": "2025-07-01T12:19:20.624811"
+    },
+    "interleavefasta - five files": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,351155e045aaf4e93cdf2481b9392047"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,d068b70bd89339c1cf161f53f987eb6b"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,351155e045aaf4e93cdf2481b9392047"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,d068b70bd89339c1cf161f53f987eb6b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-10T14:12:56.718248"
     }
 }

--- a/modules/gallvp/custom/rmouttogff3/meta.yml
+++ b/modules/gallvp/custom/rmouttogff3/meta.yml
@@ -25,21 +25,25 @@ input:
         type: file
         description: RepeatMasker out file
         pattern: "*.out"
+        ontologies: []
 output:
-  - gff3:
-      - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. `[ id:'sample1' ]`
+  gff3:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
       - "*.gff3":
-        type: file
-        description: GFF3 formatted output
-  - versions:
-      - versions.yml:
           type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          description: GFF3 formatted output
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@GallVp"
 maintainers:

--- a/modules/gallvp/haphic/refsort/main.nf
+++ b/modules/gallvp/haphic/refsort/main.nf
@@ -27,8 +27,8 @@ process HAPHIC_REFSORT {
     def fasta_arg = fasta ? "--fasta $fasta" : ''
     def ref_order_arg = ref_order ? "--ref_order $ref_order" : ''
     def fout_arg = fasta ? "--fout ${prefix}.fasta" : ''
-    if( "$agp" == "${prefix}.agp" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
-    if( "$fasta" == "${prefix}.fasta" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if( "$agp" == "${prefix}.agp" ) error "Input and output AGP names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if( "$fasta" == "${prefix}.fasta" ) error "Input and output Fasta names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     haphic \\
         refsort \\
@@ -48,8 +48,8 @@ process HAPHIC_REFSORT {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if( "$agp" == "${prefix}.agp" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
-    if( "$fasta" == "${prefix}.fasta" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if( "$agp" == "${prefix}.agp" ) error "Input and output AGP names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if( "$fasta" == "${prefix}.fasta" ) error "Input and output Fasta names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     touch ${prefix}.agp
 

--- a/modules/gallvp/haphic/refsort/meta.yml
+++ b/modules/gallvp/haphic/refsort/meta.yml
@@ -31,25 +31,25 @@ input:
         pattern: "*.{agp}"
 
         ontologies: []
-  - - paf:
-        type: file
-        description: Alignment PAF
-        pattern: "*.{paf}"
+  - paf:
+      type: file
+      description: Alignment PAF
+      pattern: "*.{paf}"
 
-        ontologies: []
-  - - fasta:
-        type: file
-        description: Query Fasta
-        pattern: "*.{fasta}"
+      ontologies: []
+  - fasta:
+      type: file
+      description: Query Fasta
+      pattern: "*.{fasta}"
 
-        ontologies: []
-  - - ref_order:
-        type: string
-        description: Order of reference chromosomes
+      ontologies: []
+  - ref_order:
+      type: string
+      description: Order of reference chromosomes
 
 output:
-  - agp:
-      - meta:
+  agp:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -60,8 +60,8 @@ output:
           pattern: "*.{agp}"
 
           ontologies: []
-  - fasta:
-      - meta:
+  fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -72,14 +72,14 @@ output:
           pattern: "*.{fasta}"
 
           ontologies: []
-  - versions:
-      - "versions.yml":
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
 
-          ontologies:
-            - edam: http://edamontology.org/format_3750 # YAML
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@GallVp"
 maintainers:

--- a/modules/gallvp/repeatmasker/repeatmasker/environment.yml
+++ b/modules/gallvp/repeatmasker/repeatmasker/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::repeatmasker=4.1.5

--- a/modules/gallvp/repeatmasker/repeatmasker/main.nf
+++ b/modules/gallvp/repeatmasker/repeatmasker/main.nf
@@ -1,0 +1,68 @@
+process REPEATMASKER_REPEATMASKER {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/repeatmasker:4.1.5--pl5321hdfd78af_0':
+        'biocontainers/repeatmasker:4.1.5--pl5321hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    path(lib)
+
+    output:
+    tuple val(meta), path("${prefix}.masked")   , emit: masked
+    tuple val(meta), path("${prefix}.out")      , emit: out
+    tuple val(meta), path("${prefix}.tbl")      , emit: tbl
+    tuple val(meta), path("${prefix}.gff")      , emit: gff         , optional: true
+    path "versions.yml"                         , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args    = task.ext.args     ?: ''
+    prefix      = task.ext.prefix   ?: "${meta.id}"
+    def lib_arg = lib               ? "-lib $lib"   : ''
+
+    def out_fasta    = fasta.getBaseName(fasta.name.endsWith('.gz') ? 1 : 0)
+    def fasta_gz_cmd = fasta.name.endsWith('.gz') ? "gunzip -c ${fasta} > ${out_fasta}" : ""
+
+    """
+    ${fasta_gz_cmd}
+    RepeatMasker \\
+        $lib_arg \\
+        -pa ${task.cpus} \\
+        -dir ${prefix} \\
+        ${args} \\
+        ${out_fasta}
+
+    mv $prefix/${out_fasta}.masked  ${prefix}.masked
+    mv $prefix/${out_fasta}.out     ${prefix}.out
+    mv $prefix/${out_fasta}.tbl     ${prefix}.tbl
+    mv $prefix/${out_fasta}.out.gff ${prefix}.gff       || echo "GFF is not produced"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        repeatmasker: \$(RepeatMasker -v | sed 's/RepeatMasker version //1')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix          = task.ext.prefix       ?: "${meta.id}"
+    def args        = task.ext.args         ?: ''
+    def touch_gff   = args.contains('-gff') ? "touch ${prefix}.gff" : ''
+
+    """
+    touch ${prefix}.masked
+    touch ${prefix}.out
+    touch ${prefix}.tbl
+    $touch_gff
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        repeatmasker: \$(RepeatMasker -v | sed 's/RepeatMasker version //1')
+    END_VERSIONS
+    """
+}

--- a/modules/gallvp/repeatmasker/repeatmasker/meta.yml
+++ b/modules/gallvp/repeatmasker/repeatmasker/meta.yml
@@ -1,0 +1,99 @@
+name: repeatmasker_repeatmasker
+description: |
+  Screening DNA sequences for interspersed repeats and low complexity DNA sequences
+
+keywords:
+  - genome
+  - annotation
+  - repeat
+  - mask
+
+tools:
+  - repeatmasker:
+      description: |
+        RepeatMasker is a program that screens DNA sequences for interspersed
+        repeats and low complexity DNA sequences
+      homepage: "https://www.repeatmasker.org/"
+      documentation: "https://www.repeatmasker.org/webrepeatmaskerhelp.html"
+      tool_dev_url: "https://github.com/rmhubley/RepeatMasker"
+      licence: ["Open Software License v. 2.1"]
+      identifier: biotools:repeatmasker
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - fasta:
+        type: file
+        description: Genome assembly
+        pattern: "*.{fasta,fa,fas,fsa,faa,fna}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+  - lib:
+      type: file
+      description: Custom library (e.g. from another species)
+      pattern: "*.{fasta,fa,fas,fsa,faa,fna}"
+      ontologies:
+        - edam: http://edamontology.org/format_1929 # FASTA
+output:
+  masked:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.masked:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+  out:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.out:
+          type: file
+          description: Out file
+          pattern: "*.{out}"
+          ontologies: []
+  tbl:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.tbl:
+          type: file
+          description: tbl file
+          pattern: "*.{tbl}"
+          ontologies: []
+  gff:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.gff:
+          type: file
+          description: GFF file
+          pattern: "*.{gff}"
+          ontologies:
+            - edam: http://edamontology.org/format_2305
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@kherronism"
+  - "@gallvp"
+
+maintainers:
+  - "@kherronism"
+  - "@gallvp"

--- a/modules/gallvp/repeatmasker/repeatmasker/meta.yml
+++ b/modules/gallvp/repeatmasker/repeatmasker/meta.yml
@@ -44,7 +44,7 @@ output:
           description: Masked fasta
           pattern: "*.{masked}"
           ontologies: []
-      - ${prefix}.masked:
+      - "${prefix}.masked":
           type: file
           description: Masked fasta
           pattern: "*.{masked}"
@@ -55,7 +55,7 @@ output:
           description: Masked fasta
           pattern: "*.{masked}"
           ontologies: []
-      - ${prefix}.out:
+      - "${prefix}.out":
           type: file
           description: Out file
           pattern: "*.{out}"
@@ -66,7 +66,7 @@ output:
           description: Masked fasta
           pattern: "*.{masked}"
           ontologies: []
-      - ${prefix}.tbl:
+      - "${prefix}.tbl":
           type: file
           description: tbl file
           pattern: "*.{tbl}"
@@ -77,7 +77,7 @@ output:
           description: Masked fasta
           pattern: "*.{masked}"
           ontologies: []
-      - ${prefix}.gff:
+      - "${prefix}.gff":
           type: file
           description: GFF file
           pattern: "*.{gff}"

--- a/modules/gallvp/repeatmasker/repeatmasker/tests/main.nf.test
+++ b/modules/gallvp/repeatmasker/repeatmasker/tests/main.nf.test
@@ -1,0 +1,106 @@
+nextflow_process {
+
+    name "Test Process REPEATMASKER_REPEATMASKER"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "REPEATMASKER_REPEATMASKER"
+
+    tag "modules"
+    tag "modules_gallvp"
+    tag "repeatmasker"
+    tag "repeatmasker/repeatmasker"
+
+    test("sarscov2 - genome - fasta") {
+        when {
+            params {
+                repeatmasker_args = '-no_is -gff' // Not required but significantly cuts the runtime
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.masked,
+                    process.out.out,
+                    process.out.gff,
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() },
+                { assert file(process.out.tbl[0][1]).text.contains('run with rmblastn') }
+            )
+        }
+
+    }
+
+    test("sarscov2 - genome - fasta.gz") {
+        when {
+            params {
+                repeatmasker_args = '-no_is -gff' // Not required but significantly cuts the runtime
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.masked,
+                    process.out.out,
+                    process.out.gff,
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() },
+                { assert file(process.out.tbl[0][1]).text.contains('run with rmblastn') }
+            )
+        }
+
+    }
+
+    test("sarscov2 - genome - fasta - stub") {
+
+        options '-stub'
+
+        when {
+            params {
+                repeatmasker_args = '-gff'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+            ).match()
+        }
+
+    }
+
+}

--- a/modules/gallvp/repeatmasker/repeatmasker/tests/main.nf.test.snap
+++ b/modules/gallvp/repeatmasker/repeatmasker/tests/main.nf.test.snap
@@ -1,0 +1,170 @@
+{
+    "sarscov2 - genome - fasta": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.masked:md5,c0eb8dd958ce3b4b1fdc7fcb6b0d5161"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.out:md5,8610cb2b8d87356bf2ab0a895c065752"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gff:md5,289cdcae609a8c450a20080107ea6351"
+                ]
+            ],
+            [
+                "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+            ],
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:28:28.754319473"
+    },
+    "sarscov2 - genome - fasta.gz": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.masked:md5,c0eb8dd958ce3b4b1fdc7fcb6b0d5161"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.out:md5,8610cb2b8d87356bf2ab0a895c065752"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gff:md5,289cdcae609a8c450a20080107ea6351"
+                ]
+            ],
+            [
+                "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+            ],
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:29:16.280370801"
+    },
+    "sarscov2 - genome - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.masked:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tbl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "masked": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.masked:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "out": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbl": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tbl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+                ]
+            },
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:59:31.7951404"
+    }
+}

--- a/modules/gallvp/repeatmasker/repeatmasker/tests/nextflow.config
+++ b/modules/gallvp/repeatmasker/repeatmasker/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: REPEATMASKER_REPEATMASKER {
+        ext.args = params.repeatmasker_args
+    }
+}

--- a/nf-core-hybridisation.sh
+++ b/nf-core-hybridisation.sh
@@ -9,6 +9,7 @@ cp_hybrid_module() {
 # Modules for module testing
 cp_hybrid_module "gunzip"
 cp_hybrid_module "minimap2/align"
+cp_hybrid_module "repeatmasker/repeatmasker"
 
 # Modules for hybrid sub-workflows
 cp_hybrid_module "agat/spextractsequences"

--- a/nf-core-modules/modules.json
+++ b/nf-core-modules/modules.json
@@ -105,6 +105,11 @@
                         "git_sha": "a532706a19b3d83f14b1d48a6a815ed33eb48b0c",
                         "installed_by": ["modules"]
                     },
+                    "repeatmasker/repeatmasker": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
                     "samblaster": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/environment.yml
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::repeatmasker=4.1.5

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/main.nf
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/main.nf
@@ -1,0 +1,68 @@
+process REPEATMASKER_REPEATMASKER {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/repeatmasker:4.1.5--pl5321hdfd78af_0':
+        'biocontainers/repeatmasker:4.1.5--pl5321hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    path(lib)
+
+    output:
+    tuple val(meta), path("${prefix}.masked")   , emit: masked
+    tuple val(meta), path("${prefix}.out")      , emit: out
+    tuple val(meta), path("${prefix}.tbl")      , emit: tbl
+    tuple val(meta), path("${prefix}.gff")      , emit: gff         , optional: true
+    path "versions.yml"                         , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args    = task.ext.args     ?: ''
+    prefix      = task.ext.prefix   ?: "${meta.id}"
+    def lib_arg = lib               ? "-lib $lib"   : ''
+
+    def out_fasta    = fasta.getBaseName(fasta.name.endsWith('.gz') ? 1 : 0)
+    def fasta_gz_cmd = fasta.name.endsWith('.gz') ? "gunzip -c ${fasta} > ${out_fasta}" : ""
+
+    """
+    ${fasta_gz_cmd}
+    RepeatMasker \\
+        $lib_arg \\
+        -pa ${task.cpus} \\
+        -dir ${prefix} \\
+        ${args} \\
+        ${out_fasta}
+
+    mv $prefix/${out_fasta}.masked  ${prefix}.masked
+    mv $prefix/${out_fasta}.out     ${prefix}.out
+    mv $prefix/${out_fasta}.tbl     ${prefix}.tbl
+    mv $prefix/${out_fasta}.out.gff ${prefix}.gff       || echo "GFF is not produced"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        repeatmasker: \$(RepeatMasker -v | sed 's/RepeatMasker version //1')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix          = task.ext.prefix       ?: "${meta.id}"
+    def args        = task.ext.args         ?: ''
+    def touch_gff   = args.contains('-gff') ? "touch ${prefix}.gff" : ''
+
+    """
+    touch ${prefix}.masked
+    touch ${prefix}.out
+    touch ${prefix}.tbl
+    $touch_gff
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        repeatmasker: \$(RepeatMasker -v | sed 's/RepeatMasker version //1')
+    END_VERSIONS
+    """
+}

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/meta.yml
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/meta.yml
@@ -1,0 +1,99 @@
+name: repeatmasker_repeatmasker
+description: |
+  Screening DNA sequences for interspersed repeats and low complexity DNA sequences
+
+keywords:
+  - genome
+  - annotation
+  - repeat
+  - mask
+
+tools:
+  - repeatmasker:
+      description: |
+        RepeatMasker is a program that screens DNA sequences for interspersed
+        repeats and low complexity DNA sequences
+      homepage: "https://www.repeatmasker.org/"
+      documentation: "https://www.repeatmasker.org/webrepeatmaskerhelp.html"
+      tool_dev_url: "https://github.com/rmhubley/RepeatMasker"
+      licence: ["Open Software License v. 2.1"]
+      identifier: biotools:repeatmasker
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - fasta:
+        type: file
+        description: Genome assembly
+        pattern: "*.{fasta,fa,fas,fsa,faa,fna}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+  - lib:
+      type: file
+      description: Custom library (e.g. from another species)
+      pattern: "*.{fasta,fa,fas,fsa,faa,fna}"
+      ontologies:
+        - edam: http://edamontology.org/format_1929 # FASTA
+output:
+  masked:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.masked:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+  out:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.out:
+          type: file
+          description: Out file
+          pattern: "*.{out}"
+          ontologies: []
+  tbl:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.tbl:
+          type: file
+          description: tbl file
+          pattern: "*.{tbl}"
+          ontologies: []
+  gff:
+    - - meta:
+          type: file
+          description: Masked fasta
+          pattern: "*.{masked}"
+          ontologies: []
+      - ${prefix}.gff:
+          type: file
+          description: GFF file
+          pattern: "*.{gff}"
+          ontologies:
+            - edam: http://edamontology.org/format_2305
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@kherronism"
+  - "@gallvp"
+
+maintainers:
+  - "@kherronism"
+  - "@gallvp"

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/main.nf.test
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/main.nf.test
@@ -1,0 +1,106 @@
+nextflow_process {
+
+    name "Test Process REPEATMASKER_REPEATMASKER"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "REPEATMASKER_REPEATMASKER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "repeatmasker"
+    tag "repeatmasker/repeatmasker"
+
+    test("sarscov2 - genome - fasta") {
+        when {
+            params {
+                repeatmasker_args = '-no_is -gff' // Not required but significantly cuts the runtime
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.masked,
+                    process.out.out,
+                    process.out.gff,
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() },
+                { assert file(process.out.tbl[0][1]).text.contains('run with rmblastn') }
+            )
+        }
+
+    }
+
+    test("sarscov2 - genome - fasta.gz") {
+        when {
+            params {
+                repeatmasker_args = '-no_is -gff' // Not required but significantly cuts the runtime
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.masked,
+                    process.out.out,
+                    process.out.gff,
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() },
+                { assert file(process.out.tbl[0][1]).text.contains('run with rmblastn') }
+            )
+        }
+
+    }
+
+    test("sarscov2 - genome - fasta - stub") {
+
+        options '-stub'
+
+        when {
+            params {
+                repeatmasker_args = '-gff'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+            ).match()
+        }
+
+    }
+
+}

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/main.nf.test.snap
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/main.nf.test.snap
@@ -1,0 +1,170 @@
+{
+    "sarscov2 - genome - fasta": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.masked:md5,c0eb8dd958ce3b4b1fdc7fcb6b0d5161"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.out:md5,8610cb2b8d87356bf2ab0a895c065752"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gff:md5,289cdcae609a8c450a20080107ea6351"
+                ]
+            ],
+            [
+                "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+            ],
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:28:28.754319473"
+    },
+    "sarscov2 - genome - fasta.gz": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.masked:md5,c0eb8dd958ce3b4b1fdc7fcb6b0d5161"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.out:md5,8610cb2b8d87356bf2ab0a895c065752"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gff:md5,289cdcae609a8c450a20080107ea6351"
+                ]
+            ],
+            [
+                "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+            ],
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:29:16.280370801"
+    },
+    "sarscov2 - genome - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.masked:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tbl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "masked": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.masked:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "out": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbl": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tbl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,1386abb5112b809c321da8ddc598c573"
+                ]
+            },
+            {
+                "REPEATMASKER_REPEATMASKER": {
+                    "repeatmasker": "4.1.5"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-06-09T14:59:31.7951404"
+    }
+}

--- a/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/nextflow.config
+++ b/nf-core-modules/modules/nf-core/repeatmasker/repeatmasker/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: REPEATMASKER_REPEATMASKER {
+        ext.args = params.repeatmasker_args
+    }
+}

--- a/subworkflows/gallvp/fasta_seqkit_refsort/main.nf
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/main.nf
@@ -24,94 +24,94 @@ workflow FASTA_SEQKIT_REFSORT {
                                             : ch_fasta
     ch_versions                             = ch_versions.mix(SEQKIT_SORT.out.versions.first())
 
-    // Channels: ch_grouped_fastas, ch_single_fasta, ch_paired_fastas, ch_refsort_paired_fastas
-    ch_combinations_list                    = ( val_fasta_combinations == null || val_fasta_combinations == [] )
+    // Channels: ch_grouped_fastas, ch_single_fasta, ch_paired_fastas, ch_minimap_inputs
+    ch_combinations                         = ( val_fasta_combinations == null || val_fasta_combinations == [] )
                                             ? ch_fasta
                                             | map { meta, _fasta -> meta.id }
-                                            | collect
                                             : Channel.of(
                                                 val_fasta_combinations.tokenize( ' ' )
                                             )
+                                            | flatten
 
     ch_grouped_fastas                       = ch_sorted_fasta
-                                            | combine (
-                                                ch_combinations_list
-                                                | flatten
-                                            )
+                                            | combine ( ch_combinations )
                                             | filter { meta, _fasta, comb -> meta.id in comb.tokenize( ':' ) }
                                             | map { meta, fasta, comb ->
-                                                [ comb, meta, fasta ]
+                                                [ comb, meta + [ comb: comb ], fasta ] // meta2: meta + [comb:]
                                             }
                                             | groupTuple
-                                            | map { group_key, metas, fastas ->
-
-                                                if ( metas.size() == 1 ) {
-                                                    return [ metas, fastas ]
-                                                }
-
-                                                def group_ids = group_key.tokenize(':')
-                                                def meta_ids = metas.collect { it.id }
-
-                                                def query_id = group_ids.first()
-                                                def ref_id = group_ids.last()
-
-                                                def query_i = meta_ids.indexOf( query_id )
-                                                def ref_i = meta_ids.indexOf( ref_id )
-
-                                                def ordered_fastas = [
-                                                    fastas[query_i],
-                                                    fastas[ref_i],
-                                                ]
-
-                                                def new_id = group_ids.join('_')
-
-                                                [
-                                                    [ id: new_id, query: query_id, ref: ref_id ], // meta2
-                                                    ordered_fastas
-                                                ]
-                                            }
-                                            | branch { _meta2, fastas ->
-                                                single: fastas.size() != 2
-                                                paired: fastas.size() == 2
+                                            | branch { _comb, _metas2, fastas ->
+                                                single: fastas.size() == 1
+                                                multi: fastas.size() > 1
                                             }
 
     ch_single_fasta                         = ch_grouped_fastas.single
-                                            | map { meta, fastas ->
-                                                [ meta.first(), fastas.first() ]
+                                            | map { _comb, metas2, fastas ->
+                                                [ metas2.first(), fastas.first() ]
                                             }
 
-    ch_paired_fastas                        = ch_grouped_fastas.paired
-    ch_refsort_paired_fastas                = val_refsort
-                                            ? ch_grouped_fastas.paired
-                                            : Channel.empty()
+    ch_paired_fastas                        = ch_grouped_fastas.multi
+                                            | flatMap { comb, metas2, fastas ->
+
+                                                def comb_ids = comb.tokenize(':') // ordered
+                                                def meta_ids = metas2.collect { it.id } // unordered
+
+                                                def ref_id = comb_ids.last()
+                                                def query_ids = comb_ids[0..-2]
+
+                                                def ref_fasta = fastas[ meta_ids.indexOf( ref_id ) ]
+
+                                                query_ids.collect { it ->
+                                                    [
+                                                        id: "${it}_${ref_id}",
+                                                        comb: comb,
+                                                        pair: "${it}:${ref_id}",
+                                                        fastas: [ fastas[ meta_ids.indexOf( it ) ], ref_fasta ]
+                                                    ]
+                                                }
+                                            }
+                                            | map { box ->
+                                                [
+                                                    [
+                                                        id: box.id,
+                                                        comb: box.comb,
+                                                        pair: box.pair
+                                                    ],
+                                                    box.fastas
+                                                ]
+                                            }
+
 
     // MODULE: MINIMAP2_ALIGN; ext.args = -x asm5 --secondary=no
+    ch_minimap_inputs                       = val_refsort
+                                            ? ch_paired_fastas
+                                            : Channel.empty()
     MINIMAP2_ALIGN (
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.first() ] },
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.last() ] },
-        false, // bam_format
-        [], // bam_format
-        false, // cigar_paf_format
-        false // cigar_bam
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.first() ] },
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.last() ] },
+        false,  // bam_format
+        [],     // bam_format
+        false,  // cigar_paf_format
+        false   // cigar_bam
     )
 
-    ch_refsort_paired_fastas_paf            = ch_refsort_paired_fastas
-                                            | join ( MINIMAP2_ALIGN.out.paf )
+    ch_minimap_inputs_paf                   = ch_minimap_inputs
+                                            | join(MINIMAP2_ALIGN.out.paf)
     ch_versions                             = ch_versions.mix(MINIMAP2_ALIGN.out.versions.first())
 
     // JUICEBOXSCRIPTS_MAKEAGPFROMFASTA
     JUICEBOXSCRIPTS_MAKEAGPFROMFASTA (
-        ch_refsort_paired_fastas.map { meta2, fastas -> [ meta2, fastas.first() ] }
+        ch_minimap_inputs.map { meta2, fastas -> [ meta2, fastas.first() ] }
     )
 
-    ch_refsort_paired_fastas_paf_query_agp  = ch_refsort_paired_fastas_paf
+    ch_minimap_inputs_paf_agp               = ch_minimap_inputs_paf
                                             | join(
                                                 JUICEBOXSCRIPTS_MAKEAGPFROMFASTA.out.agp
                                             )
     ch_versions                             = ch_versions.mix(JUICEBOXSCRIPTS_MAKEAGPFROMFASTA.out.versions.first())
 
     // MODULE: HAPHIC_REFSORT
-    ch_refsort_inputs                       = ch_refsort_paired_fastas_paf_query_agp
+    ch_refsort_inputs                       = ch_minimap_inputs_paf_agp
                                             | multiMap { meta2, fastas, paf, query_agp ->
                                                 agp:    [ meta2, query_agp ]
                                                 paf:    paf
@@ -124,13 +124,13 @@ workflow FASTA_SEQKIT_REFSORT {
         [] //ref_order
     )
 
-    ch_refsort_paired_fastas_refsort_fasta  = ch_refsort_paired_fastas
+    ch_minimap_inputs_refsort_fasta         = ch_minimap_inputs
                                             | join ( HAPHIC_REFSORT.out.fasta )
     ch_versions                             = ch_versions.mix(HAPHIC_REFSORT.out.versions.first())
 
-    // Channel: ch_ref_sorted_paired_fastas
-    ch_ref_sorted_paired_fastas             = val_refsort
-                                            ? ch_refsort_paired_fastas_refsort_fasta
+    // Channel: ch_refsort_pairs
+    ch_refsort_pairs                        = val_refsort
+                                            ? ch_minimap_inputs_refsort_fasta
                                             | map { meta2, fastas, refsort_fasta ->
                                                 [
                                                     meta2,
@@ -140,25 +140,33 @@ workflow FASTA_SEQKIT_REFSORT {
                                             : ch_paired_fastas
 
     // MODULE:CUSTOM_INTERLEAVEFASTA
-    ch_interleave_input                     = ch_ref_sorted_paired_fastas
-                                            | multiMap { meta2, fastas ->
-                                                def query_fasta = fastas.first()
-                                                def ref_fasta  = fastas.last()
+    ch_interleave_input                     = ch_refsort_pairs
+                                            | map { meta2, fastas ->
+                                                [
+                                                    meta2.comb,
+                                                    meta2,
+                                                    fastas
+                                                ]
+                                            }
+                                            | groupTuple
+                                            | multiMap { comb, metas2, fastas ->
+                                                def unordered_fastas = fastas.collect { it.first() } + [ fastas.first().last() ]
 
-                                                def query_prefix = meta2.query
-                                                def ref_prefix = meta2.ref
+                                                def unordered_ids = metas2.collect { meta -> meta.pair.tokenize(':').first() } + [ comb.tokenize(':').last() ]
+                                                def ordered_ids = comb.tokenize(':')
 
-                                                fasta1:         [ [ id: meta2.id ], query_fasta ]
-                                                fasta2:         ref_fasta
-                                                fasta1_prefix:  query_prefix
-                                                fasta2_prefix:  ref_prefix
+
+                                                fastas: [
+                                                        [ id: comb.tokenize(':').join('_'), comb: comb ],
+                                                        ordered_ids.collect { id -> unordered_fastas[ unordered_ids.indexOf( id ) ] }
+                                                    ]
+                                                prefixes: ordered_ids.join( ' ' )
                                             }
 
+
     CUSTOM_INTERLEAVEFASTA (
-        ch_interleave_input.fasta1,
-        ch_interleave_input.fasta2,
-        ch_interleave_input.fasta1_prefix,
-        ch_interleave_input.fasta2_prefix,
+        ch_interleave_input.fastas,
+        ch_interleave_input.prefixes
     )
 
     ch_interleaved_fasta                    = CUSTOM_INTERLEAVEFASTA.out.fasta
@@ -166,6 +174,6 @@ workflow FASTA_SEQKIT_REFSORT {
 
     emit:
     fasta                                   = ch_interleaved_fasta
-                                            | mix ( ch_single_fasta )   // channel: [ meta3, fasta ]; meta3 ~ [ id ]
+                                            | mix ( ch_single_fasta )   // channel: [ meta3, fasta ]; meta3 ~ [ id, comb ]
     versions                                = ch_versions               // channel: [ versions.yml ]
 }

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
@@ -27,6 +27,10 @@ nextflow_workflow {
                         file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
                     ],
                     [
+                        [ id: 'query2' ],
+                        file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
+                    ],
+                    [
                         [ id: 'ref' ],
                         file(params.modules_testdata_base_path + 'genomics/eukaryotes/actinidia_chinensis/genome/chr1/genome.fasta.gz', checkIfExists: true)
                     ],
@@ -65,6 +69,27 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = "query query:ref ref"
+                input[2] = true
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+
+    test("HY - actinidia_chinensis - fasta - combinations - 3") {
+
+        when {
+            workflow {
+                """
+                input[0] = GUNZIP.out.gunzip
+                input[1] = "query query1:query:ref ref"
                 input[2] = true
                 input[3] = true
                 """

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test
@@ -27,7 +27,7 @@ nextflow_workflow {
                         file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
                     ],
                     [
-                        [ id: 'query2' ],
+                        [ id: 'query1' ],
                         file('https://github.com/Plant-Food-Research-Open/assemblyqc/raw/4f9fba392cf7212d61c6245fd72339e09164ce44/tests/hic/testdata/HYh1h2_Chr01_6000000_6015000.fasta.gz')
                     ],
                     [

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
@@ -5,19 +5,22 @@
                 "0": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "HYh1h2_Chr01_6000000_6015000.fasta:md5,698715c5989f43041a04f6fdca846974"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "genome.fasta:md5,d07bc737a8ba2db4ea02872a73dace0b"
                     ]
@@ -28,19 +31,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "HYh1h2_Chr01_6000000_6015000.fasta:md5,698715c5989f43041a04f6fdca846974"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "genome.fasta:md5,d07bc737a8ba2db4ea02872a73dace0b"
                     ]
@@ -52,9 +58,80 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-02T10:18:34.182968"
+        "timestamp": "2025-07-14T11:19:18.988874"
+    },
+    "HY - actinidia_chinensis - fasta - combinations - 3": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "query",
+                            "comb": "query"
+                        },
+                        "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "query1_query_ref",
+                            "comb": "query1:query:ref"
+                        },
+                        "query1_query_ref.fasta:md5,312e4da3d66e0003300787af18b9bc59"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
+                        },
+                        "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0b0eba6b6f07300cd87c276e0a55424d",
+                    "versions.yml:md5,5772594d0b3e1f41b2730f1dda23465b",
+                    "versions.yml:md5,7cd4eb452407fcd946428f758c97442d",
+                    "versions.yml:md5,c2aa26eec40ab4040601c089970c815c",
+                    "versions.yml:md5,c8fc50b7f6a91b026265c5202a63fbc7"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "query",
+                            "comb": "query"
+                        },
+                        "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "query1_query_ref",
+                            "comb": "query1:query:ref"
+                        },
+                        "query1_query_ref.fasta:md5,312e4da3d66e0003300787af18b9bc59"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
+                        },
+                        "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0b0eba6b6f07300cd87c276e0a55424d",
+                    "versions.yml:md5,5772594d0b3e1f41b2730f1dda23465b",
+                    "versions.yml:md5,7cd4eb452407fcd946428f758c97442d",
+                    "versions.yml:md5,c2aa26eec40ab4040601c089970c815c",
+                    "versions.yml:md5,c8fc50b7f6a91b026265c5202a63fbc7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-14T11:24:39.1962"
     },
     "HY - actinidia_chinensis - fasta": {
         "content": [
@@ -62,13 +139,22 @@
                 "0": [
                     [
                         {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query2",
+                            "comb": "query2"
+                        },
+                        "query2.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -79,13 +165,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query2",
+                            "comb": "query2"
+                        },
+                        "query2.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -97,9 +192,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-06-23T16:37:58.264534"
+        "timestamp": "2025-07-14T11:12:05.128217"
     },
     "HY - actinidia_chinensis - fasta - combinations": {
         "content": [
@@ -107,19 +202,22 @@
                 "0": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -134,19 +232,22 @@
                 "fasta": [
                     [
                         {
-                            "id": "query_ref"
-                        },
-                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
-                    ],
-                    [
-                        {
-                            "id": "query"
+                            "id": "query",
+                            "comb": "query"
                         },
                         "query.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
-                            "id": "ref"
+                            "id": "query_ref",
+                            "comb": "query:ref"
+                        },
+                        "query_ref.fasta:md5,7e52d0a17de86f5b11dd4d77c8332fa6"
+                    ],
+                    [
+                        {
+                            "id": "ref",
+                            "comb": "ref"
                         },
                         "ref.fasta:md5,7315276c0e677b424e673562f48b9873"
                     ]
@@ -162,8 +263,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-02T10:18:26.935545"
+        "timestamp": "2025-07-14T11:18:57.443951"
     }
 }

--- a/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
+++ b/subworkflows/gallvp/fasta_seqkit_refsort/tests/main.nf.test.snap
@@ -146,10 +146,10 @@
                     ],
                     [
                         {
-                            "id": "query2",
-                            "comb": "query2"
+                            "id": "query1",
+                            "comb": "query1"
                         },
-                        "query2.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                        "query1.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
@@ -172,10 +172,10 @@
                     ],
                     [
                         {
-                            "id": "query2",
-                            "comb": "query2"
+                            "id": "query1",
+                            "comb": "query1"
                         },
-                        "query2.fasta:md5,bcc14495671d77033b36be11fc20652c"
+                        "query1.fasta:md5,bcc14495671d77033b36be11fc20652c"
                     ],
                     [
                         {
@@ -194,7 +194,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-14T11:12:05.128217"
+        "timestamp": "2025-07-14T14:50:26.212818"
     },
     "HY - actinidia_chinensis - fasta - combinations": {
         "content": [


### PR DESCRIPTION
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] Now fasta_seqkit_refsort supports n-genome combinations
- [ ] Followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
